### PR TITLE
pre-release: No longer depend on kubectl

### DIFF
--- a/docs/pre-release/faqs.md
+++ b/docs/pre-release/faqs.md
@@ -99,7 +99,11 @@ Running this command will also stop the local daemon running.
 
 ** How does Telepresence connect and tunnel into the Kubernetes cluster?**
 
- The connection between your laptop and cluster is established via the standard `kubectl` mechanisms and SSH tunnelling.
+The connection between your laptop and cluster is established by using
+the `kubectl port-forward` machinery (though without actually spawning
+a separate program) to establish a TCP connection to Telepresence
+Traffic Manager in the cluster, and running Telepresence's custom VPN
+protocol over that TCP connection.
 
 <a name="idps"></a>
 

--- a/docs/pre-release/howtos/intercepts.md
+++ b/docs/pre-release/howtos/intercepts.md
@@ -23,7 +23,15 @@ import QSCards from '../quick-start/qs-cards'
 <Alert severity="info">For a detailed walk-though on creating intercepts using our sample app, follow the <a href="../../quick-start/qs-node/">quick start guide</a>.</Alert>
 
 ## Prerequisites
-You’ll need [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and [set up](https://kubernetes.io/docs/tasks/tools/install-kubectl/#verifying-kubectl-configuration) to use a Kubernetes cluster, preferably an empty test cluster.
+
+You’ll need [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or `oc` installed
+and set up
+([Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#verify-kubectl-configuration) /
+ [macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#verify-kubectl-configuration) /
+ [Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#verify-kubectl-configuration))
+to use a Kubernetes cluster, preferably an empty test cluster.  This
+document uses `kubectl` in all example commands, but OpenShift
+users should have no problem substituting in the `oc` command instead.
 
 If you have used Telepresence previously, please first reset your Telepresence deployment with:
 `telepresence uninstall --everything`.

--- a/docs/pre-release/quick-start/qs-go.md
+++ b/docs/pre-release/quick-start/qs-go.md
@@ -34,12 +34,15 @@ import QSCards from './qs-cards'
 </div>
 
 ## Prerequisites
-You’ll need [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/#kubectl)
+
+You’ll need [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or `oc` installed
 and set up
 ([Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#verify-kubectl-configuration) /
  [macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#verify-kubectl-configuration) /
  [Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#verify-kubectl-configuration))
-to use a Kubernetes cluster, preferably an empty test cluster.
+to use a Kubernetes cluster, preferably an empty test cluster.  This
+document uses `kubectl` in all example commands, but OpenShift
+users should have no problem substituting in the `oc` command instead.
 
 <Alert severity="info">
     <strong>Need a cluster?</strong> We provide free demo clusters preconfigured to follow this quick start. <a href="../demo-node/">Switch over to that version of the guide here</a>.

--- a/docs/pre-release/quick-start/qs-java.md
+++ b/docs/pre-release/quick-start/qs-java.md
@@ -34,12 +34,15 @@ import QSCards from './qs-cards'
 </div>
 
 ## Prerequisites
-You’ll need [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/#kubectl)
+
+You’ll need [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or `oc` installed
 and set up
 ([Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#verify-kubectl-configuration) /
  [macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#verify-kubectl-configuration) /
  [Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#verify-kubectl-configuration))
-to use a Kubernetes cluster, preferably an empty test cluster.
+to use a Kubernetes cluster, preferably an empty test cluster.  This
+document uses `kubectl` in all example commands, but OpenShift
+users should have no problem substituting in the `oc` command instead.
 
 <Alert severity="info">
     <strong>Need a cluster?</strong> We provide free demo clusters preconfigured to follow this quick start. <a href="../demo-node/">Switch over to that version of the guide here</a>.

--- a/docs/pre-release/quick-start/qs-node.md
+++ b/docs/pre-release/quick-start/qs-node.md
@@ -34,12 +34,15 @@ import QSCards from './qs-cards'
 </div>
 
 ## Prerequisites
-You’ll need [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/#kubectl)
+
+You’ll need [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or `oc` installed
 and set up
 ([Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#verify-kubectl-configuration) /
  [macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#verify-kubectl-configuration) /
  [Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#verify-kubectl-configuration))
-to use a Kubernetes cluster, preferably an empty test cluster.
+to use a Kubernetes cluster, preferably an empty test cluster.  This
+document uses `kubectl` in all example commands, but OpenShift
+users should have no problem substituting in the `oc` command instead.
 
 <Alert severity="info">
     <strong>Need a cluster?</strong> We provide free demo clusters preconfigured to follow this quick start. <a href="../demo-node/">Switch over to that version of the guide here</a>.

--- a/docs/pre-release/quick-start/qs-python-fastapi.md
+++ b/docs/pre-release/quick-start/qs-python-fastapi.md
@@ -34,12 +34,15 @@ import QSCards from './qs-cards'
 </div>
 
 ## Prerequisites
-You’ll need [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/#kubectl)
+
+You’ll need [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or `oc` installed
 and set up
 ([Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#verify-kubectl-configuration) /
  [macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#verify-kubectl-configuration) /
  [Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#verify-kubectl-configuration))
-to use a Kubernetes cluster, preferably an empty test cluster.
+to use a Kubernetes cluster, preferably an empty test cluster.  This
+document uses `kubectl` in all example commands, but OpenShift
+users should have no problem substituting in the `oc` command instead.
 
 <Alert severity="info">
     <strong>Need a cluster?</strong> We provide free demo clusters preconfigured to follow this quick start. <a href="../demo-node/">Switch over to that version of the guide here</a>.

--- a/docs/pre-release/quick-start/qs-python.md
+++ b/docs/pre-release/quick-start/qs-python.md
@@ -34,12 +34,15 @@ import QSCards from './qs-cards'
 </div>
 
 ## Prerequisites
-You’ll need [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/#kubectl)
+
+You’ll need [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or `oc` installed
 and set up
 ([Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#verify-kubectl-configuration) /
  [macOS](https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#verify-kubectl-configuration) /
  [Windows](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#verify-kubectl-configuration))
-to use a Kubernetes cluster, preferably an empty test cluster.
+to use a Kubernetes cluster, preferably an empty test cluster.  This
+document uses `kubectl` in all example commands, but OpenShift
+users should have no problem substituting in the `oc` command instead.
 
 <Alert severity="info">
     <strong>Need a cluster?</strong> We provide free demo clusters preconfigured to follow this quick start. <a href="../demo-node/">Switch over to that version of the guide here</a>.

--- a/docs/pre-release/reference/inside-container.md
+++ b/docs/pre-release/reference/inside-container.md
@@ -11,22 +11,11 @@ Building a container with a ready-to-run Telepresence is easy because there are 
 FROM alpine:3.13
 
 # Install Telepresence prerequisites
-RUN apk add --no-cache curl iproute2 sshfs bash
-
-# Download and install the kubectl binary
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
-   install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+RUN apk add --no-cache curl iproute2 sshfs
 
 # Download and install the telepresence binary
 RUN curl -fL https://app.getambassador.io/download/tel2/linux/amd64/latest/telepresence -o telepresence && \
    install -o root -g root -m 0755 telepresence /usr/local/bin/telepresence
-
-# Add some convenient aliases to .bashrc
-RUN echo -e '\
-alias t=telepresence\n\
-alias k=kubectl\n\
-' >> /root/.bashrc
-
 ```
 In order to build the container, do this in the same directory as the `Dockerfile`:
 ```
@@ -44,5 +33,5 @@ $ docker run \
   --device /dev/net/tun:/dev/net/tun \
   --network=host \
   -v ~/.kube/config:/root/.kube/config \
-  -it --rm tp-in-docker /bin/bash
+  -it --rm tp-in-docker
 ```

--- a/docs/pre-release/reference/tun-device.md
+++ b/docs/pre-release/reference/tun-device.md
@@ -11,7 +11,14 @@ The VIF is a TUN-device, which means that it communicates with the workstation i
 The TUN-device is capable of routing both TCP and UDP for outbound traffic. Earlier versions of Telepresence would only allow TCP. Future enhancements might be to also route inbound UDP, and perhaps a selection of ICMP packages (to allow for things like `ping`).
 
 ### No SSH required
-The VIF approach is somewhat similar to using `sshuttle` but without any requirements for extra software, configuration or connections.  Using the VIF means that only one single `kubectl port-forward`, that uses one single port, is needed during a Telepresence run. There is no need for `ssh` in the client nor for `sshd` in the traffic-manager. This also means that the traffic-manager container can run as the default user.
+
+The VIF approach is somewhat similar to using `sshuttle` but without
+any requirements for extra software, configuration or connections.
+Using the VIF means that only one single connection needs to be
+forwarded through the Kubernetes apiserver (à la `kubectl
+port-forward`), using only one single port.  There is no need for
+`ssh` in the client nor for `sshd` in the traffic-manager.  This also
+means that the traffic-manager container can run as the default user.
 
 #### sshfs without ssh encryption
 When a POD is intercepted, and its volumes are mounted on the local machine, this mount is performed by [sshfs](https://github.com/libfuse/sshfs). Telepresence will run `sshfs -o slave` which means that instead of using `ssh` to establish an encrypted communication to an `sshd`, which in turn terminates the encryption and forwards to `sftp`, the `sshfs` will talk `sftp` directly on its `stdin/stdout` pair. Telepresence tunnels that directly to an `sftp` in the agent using its already encrypted gRPC API. As a result, no `sshd` is needed in client nor in the traffic-agent, and the traffic-agent container can run as the default user.

--- a/docs/pre-release/releaseNotes.yml
+++ b/docs/pre-release/releaseNotes.yml
@@ -32,7 +32,14 @@ changelog: https://github.com/telepresenceio/telepresence/blob/$branch$/CHANGELO
 items:
   - version: 2.y.z
     date: 'TBD'
-    notes: []
+    notes:
+      - type: feature
+        title: No more dependence on <code>kubectl</code>
+        body: >-
+          Telepresence no longer depends on having an external
+          <code>kubectl</code> binary, which might not be present for
+          OpenShift users (who have <code>oc</code> instead of
+          <code>kubectl</code>).
   - version: 2.3.2
     date: '2021-06-18'
     notes:


### PR DESCRIPTION
OpenShift users likely don't have `kubectl`.