### PR TITLE
Update docs for air-gapped client

### DIFF
--- a/docs/pre-release/install/helm.md
+++ b/docs/pre-release/install/helm.md
@@ -117,7 +117,7 @@ metadata:
 
 **NOTE** This happens automatically in kubernetes >= 1.21.
 
-### Installing RBAC only
+## Install RBAC only
 
 Telepresence Traffic Manager does require some [RBAC](../../refrence/rbac/) for the traffic-manager itself, as well as for users.
 To make it easier for operators to introspect / manage RBAC separately, you can use `rbac.only=true` to

--- a/docs/pre-release/install/helm.md
+++ b/docs/pre-release/install/helm.md
@@ -117,7 +117,7 @@ metadata:
 
 **NOTE** This happens automatically in kubernetes >= 1.21.
 
-## Install RBAC only
+### Installing RBAC only
 
 Telepresence Traffic Manager does require some [RBAC](../../refrence/rbac/) for the traffic-manager itself, as well as for users.
 To make it easier for operators to introspect / manage RBAC separately, you can use `rbac.only=true` to

--- a/docs/pre-release/reference/cluster-config.md
+++ b/docs/pre-release/reference/cluster-config.md
@@ -128,6 +128,8 @@ pulled and in a registry your cluster can pull from.
 Users will now be able to use selective intercepts with the
 `--preview-url=false` flag (since use of preview URLs requires a connection to Ambassador Cloud).
 
+If using Helm to install the server-side components, see the chart's [README](https://github.com/telepresenceio/telepresence/tree/release/v2/charts/telepresence) to learn how to configure the image registry and license secret.
+
 ## Mutating Webhook
 
 By default, Telepresence updates the intercepted workload (Deployment, StatefulSet, ReplicaSet)

--- a/docs/pre-release/reference/cluster-config.md
+++ b/docs/pre-release/reference/cluster-config.md
@@ -118,7 +118,14 @@ run this command to generate the Cluster ID:
   ```
 
 3. Save the output as a YAML file and apply it to your
-cluster with `kubectl`.  Once applied, you will be able to use selective intercepts with the
+cluster with `kubectl`.
+
+4. Ensure that you have the docker image for the Smart Agent (datawire/ambassador-telepresence-agent:1.8.0)
+pulled and in a registry your cluster can pull from.
+
+5. Have users use the `images` [config key](../config.md#) (or environment variables) so telepresence uses the aforementioned image for their agent.
+
+Users will now be able to use selective intercepts with the
 `--preview-url=false` flag (since use of preview URLs requires a connection to Ambassador Cloud).
 
 ## Mutating Webhook

--- a/docs/pre-release/reference/config.md
+++ b/docs/pre-release/reference/config.md
@@ -58,16 +58,6 @@ These are the valid fields for the `logLevels` key:
 |`userDaemon`|Logging level to be used by the User Daemon (logs to connector.log)|debug|
 |`rootDaemon`|Logging level to be used for the Root Daemon (logs to daemon.log)|info|
 
-## Environment Variables
-Telepresence also can use Environment Variables to configure behavior.  Below is a chart listing
-the Environment Variables and which config key they map to (if applicable).  If both a config are
-specified, the Environment Variable will take precedence.
-
-|Environment Variable|Config Key|
-|---|---|
-|`TELEPRESENCE_REGISTRY`|`images.registry`|
-|`TELEPRESENCE_AGENT_IMAGE`|`images.agentImage`|
-
 ## Per-Cluster Configuration
 Some configuration is not global to Telepresence and is actually specific to a cluster.  Thus, we store that config information in your kubeconfig file, so that it is easier to maintain per-cluster configuration.
 

--- a/docs/pre-release/reference/config.md
+++ b/docs/pre-release/reference/config.md
@@ -10,7 +10,7 @@ For Linux, the above paths are for a user-level configuration. For system-level 
 
 ### Values
 
-The config file currently supports values for the `timeouts` and `logLevels` keys.
+The config file currently supports values for the `timeouts`, `logLevels`, `images` keys.
 
 Here is an example configuration:
 
@@ -20,6 +20,9 @@ timeouts:
   intercept: 10s
 logLevels:
   userDaemon: debug
+images:
+  registry: privateRepo
+  agentImage: ambassador-telepresence-agent:1.8.0
 ```
 
 #### Timeouts
@@ -37,6 +40,15 @@ These are the valid fields for the `timeouts` key:
 |`trafficManagerConnect`|Waiting for the Traffic Manager API to connect for port fowards|20 seconds|
 |`trafficManagerAPI`|Waiting for connection to the gPRC API after `trafficManagerConnect` is successful|15 seconds|
 
+#### Images
+Values for `images` are strings.
+These are the valid fields for the `images` key:
+
+|Field|Description|Default|
+|---|---|---|
+|`registry`|Docker registry to be used for installing the Traffic Manager and/or Traffic Agent|docker.io/datawire|
+|`agentImage`|$imageName:$imageTag to use when installing the Traffic Agent||
+
 #### Log Levels
 Values for `logLevels` are one of the following strings: `trace`, `debug`, `info`, `warning`, `error`, `fatal` and `panic`.
 These are the valid fields for the `logLevels` key:
@@ -45,6 +57,16 @@ These are the valid fields for the `logLevels` key:
 |---|---|---|
 |`userDaemon`|Logging level to be used by the User Daemon (logs to connector.log)|debug|
 |`rootDaemon`|Logging level to be used for the Root Daemon (logs to daemon.log)|info|
+
+## Environment Variables
+Telepresence also can use Environment Variables to configure behavior.  Below is a chart listing
+the Environment Variables and which config key they map to (if applicable).  If both a config are
+specified, the Environment Variable will take precedence.
+
+|Environment Variable|Config Key|
+|---|---|
+|`TELEPRESENCE_REGISTRY`|`images.registry`|
+|`TELEPRESENCE_AGENT_IMAGE`|`images.agentImage`|
 
 ## Per-Cluster Configuration
 Some configuration is not global to Telepresence and is actually specific to a cluster.  Thus, we store that config information in your kubeconfig file, so that it is easier to maintain per-cluster configuration.

--- a/docs/pre-release/releaseNotes.yml
+++ b/docs/pre-release/releaseNotes.yml
@@ -61,11 +61,21 @@ items:
         # image: TODO
         docs: reference/config
       - type: feature
-        title: traffic-manager in multiple namespaces
+        title: Traffic-manager in multiple namespaces
         body: >-
           We now support installing multiple traffic managers in the same cluster.
           This will allow operators to install deployments of telepresence that are
           limited to certain namespaces.
+        # image: TODO
+        docs: reference/config
+      - type: feature
+        title: Agent image now configurable
+        body: >-
+          We now support configuring which agent image + registry to use in the
+          config. This enables users whose laptop is an air-gapped environment to
+          create selective intercepts without requiring a login. It also makes it easier
+          for those who are developing on Telepresence to specify which agent image should
+          be used.
         # image: TODO
         docs: reference/config
   - version: 2.3.2


### PR DESCRIPTION
Here are the docs to support Telepresence working when a client is in an air-gapped environment.  The tl;dr of this is it already works, but a user had to set an environment variable and it wasn't clear that they *had* to.  

This docs change proposes that we move those environment variables into the config.yml as well since I think most (all?) user configuration should have an associated key in the config.