### PR TITLE
Add windows docs

### DIFF
--- a/docs/pre-release/faqs.md
+++ b/docs/pre-release/faqs.md
@@ -18,7 +18,7 @@ By using the preview URL functionality you can share access with additional deve
 
 ** What operating systems does Telepresence work on?**
 
-Telepresence currently works natively on macOS and Linux. We are working on a native Windows port, but in the meantime, Windows users can use Telepresence with WSL 2.
+Telepresence currently works natively on macOS, Linux, WSL 2, and Windows 10.
 
 ** What protocols can be intercepted by Telepresence?**
 

--- a/docs/pre-release/install/old-version-tabs.js
+++ b/docs/pre-release/install/old-version-tabs.js
@@ -8,6 +8,7 @@ import Box from '@material-ui/core/Box';
 import CodeBlock from '@src/components/CodeBlock';
 import LinuxIcon from '@src/assets/icons/linux.inline.svg';
 import AppleIcon from '@src/assets/icons/apple.inline.svg';
+import WindowsIcon from '@src/assets/icons/windows.inline.svg';
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -63,6 +64,7 @@ export default function SimpleTabs() {
         <Tabs value={value} onChange={handleChange} aria-label="operating system tabs">
           <Tab icon={<AppleIcon />} label="macOS" {...a11yProps(0)} style={{ minWidth: "10%", textTransform: 'none' }} />
           <Tab icon={<LinuxIcon />} label="Linux" {...a11yProps(1)} style={{ minWidth: "10%", textTransform: 'none' }} />
+          <Tab icon={<WindowsIcon />} label="Windows" {...a11yProps(2)} style={{ minWidth: "10%", textTransform: 'none' }} />
         </Tabs>
       </AppBar>
       <TabPanel value={value} index={0}>
@@ -76,6 +78,13 @@ export default function SimpleTabs() {
         <CodeBlock>
         {
           'https://app.getambassador.io/download/tel2/linux/amd64/x.x.x/telepresence'
+        }
+        </CodeBlock>
+      </TabPanel>
+      <TabPanel value={value} index={2}>
+        <CodeBlock>
+        {
+          'https://app.getambassador.io/download/tel2/windows/amd64/x.x.x/telepresence.msi'
         }
         </CodeBlock>
       </TabPanel>

--- a/docs/pre-release/install/upgrade-tabs.js
+++ b/docs/pre-release/install/upgrade-tabs.js
@@ -104,7 +104,7 @@ export default function SimpleTabs() {
         {
           '# 1. Download the latest binary (~50 MB):' +
           '\n' +
-                'sudo curl -fL https://app.getambassador.io/download/tel2/windows/amd64/latest/telepresence.msi -o C:\\Temp\\telepresence.msi' +
+          'curl -fL https://app.getambassador.io/download/tel2/windows/amd64/latest/telepresence.msi -o C:\\Temp\\telepresence.msi' +
           '\n \n' +
           '# 2. Run the installer in PowerShell' +
           '\n' +

--- a/docs/pre-release/install/upgrade-tabs.js
+++ b/docs/pre-release/install/upgrade-tabs.js
@@ -8,6 +8,7 @@ import Box from '@material-ui/core/Box';
 import CodeBlock from '@src/components/CodeBlock';
 import LinuxIcon from '@src/assets/icons/linux.inline.svg';
 import AppleIcon from '@src/assets/icons/apple.inline.svg';
+import WindowsIcon from '@src/assets/icons/windows.inline.svg';
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -63,6 +64,7 @@ export default function SimpleTabs() {
         <Tabs value={value} onChange={handleChange} aria-label="operating system tabs">
           <Tab icon={<AppleIcon />} label="macOS" {...a11yProps(0)} style={{ minWidth: "10%", textTransform: 'none' }} />
           <Tab icon={<LinuxIcon />} label="Linux" {...a11yProps(1)} style={{ minWidth: "10%", textTransform: 'none' }} />
+          <Tab icon={<WindowsIcon />} label="Windows" {...a11yProps(2)} style={{ minWidth: "10%", textTransform: 'none' }} />
         </Tabs>
       </AppBar>
       <TabPanel value={value} index={0}>
@@ -94,6 +96,19 @@ export default function SimpleTabs() {
           '# 2. Make the binary executable:' +
           '\n' +
           'sudo chmod a+x /usr/local/bin/telepresence'
+        }
+        </CodeBlock>
+      </TabPanel>
+      <TabPanel value={value} index={2}>
+        <CodeBlock>
+        {
+          '# 1. Download the latest binary (~50 MB):' +
+          '\n' +
+                'sudo curl -fL https://app.getambassador.io/download/tel2/windows/amd64/latest/telepresence.msi -o C:\\Temp\\telepresence.msi' +
+          '\n \n' +
+          '# 2. Run the installer in PowerShell' +
+          '\n' +
+          'Start-Process C:\\Temp\\telepresence.msi'
         }
         </CodeBlock>
       </TabPanel>

--- a/docs/pre-release/quick-start/qs-tabs.js
+++ b/docs/pre-release/quick-start/qs-tabs.js
@@ -104,7 +104,7 @@ export default function SimpleTabs() {
         {
           '# 1. Download the latest binary (~50 MB):' +
           '\n' +
-          'sudo curl -fL https://app.getambassador.io/download/tel2/windows/amd64/latest/telepresence.msi -o C:\\Temp\\telepresence.msi' +
+          'curl -fL https://app.getambassador.io/download/tel2/windows/amd64/latest/telepresence.msi -o C:\\Temp\\telepresence.msi' +
           '\n \n' +
           '# 2. Run the installer in PowerShell' +
           '\n' +

--- a/docs/pre-release/quick-start/qs-tabs.js
+++ b/docs/pre-release/quick-start/qs-tabs.js
@@ -5,7 +5,6 @@ import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Box from '@material-ui/core/Box';
-import HubspotForm from 'react-hubspot-form';
 import CodeBlock from '@src/components/CodeBlock';
 import LinuxIcon from '@src/assets/icons/linux.inline.svg';
 import AppleIcon from '@src/assets/icons/apple.inline.svg';
@@ -101,20 +100,17 @@ export default function SimpleTabs() {
         </CodeBlock>
       </TabPanel>
       <TabPanel value={value} index={2}>
-        <div className="docs-hubspot-formwrapper">
-          <p>
-            Telepresence for Windows is coming soon! Sign up here to notified when it is available. Until then, Telepresence will work with WSL 2.
-          </p>
-          <div className="docs-hubspot-form">
-            <HubspotForm
-              portalId='485087'
-              formId='2f542f1b-3da8-4319-8057-96fed78e4c26'
-              onSubmit={() => console.log('Submit!')}
-              onReady={(form) => console.log('Form ready!')}
-              loading={<div>Loading...</div>}
-            />
-          </div>
-        </div>
+        <CodeBlock>
+        {
+          '# 1. Download the latest binary (~50 MB):' +
+          '\n' +
+          'sudo curl -fL https://app.getambassador.io/download/tel2/windows/amd64/latest/telepresence.msi -o C:\\Temp\\telepresence.msi' +
+          '\n \n' +
+          '# 2. Run the installer in PowerShell' +
+          '\n' +
+          'Start-Process C:\\Temp\\telepresence.msi'
+        }
+        </CodeBlock>
       </TabPanel>
     </div >
   );


### PR DESCRIPTION
This is a best guess at what installing windows will look like. I've
used various resources (kubectl, yggdrasil-go) to get information about
how windows projects are installed, as well as how we might create an
install that is bundled with wintun.  I have never developed on windows
so there likely will be some changes once it's actually implemented but
this should give the general idea

I can't speak to this project, but in my googling I found https://github.com/yggdrasil-network/yggdrasil-go/blob/master/contrib/msi/build-msi.sh which generates an msi file for a go app that uses wintun so it might be helpful... That being said they have this notice on their website: 
```
Yggdrasil works on Windows and an MSI installer is available, but the installer is supported on a best-effort basis only and is not well tested.
``` 
which seems to be common in my searching 🤷‍♂️ . 