### PR TITLE
Update config doc section to remove privateRepo

### DIFF
--- a/docs/v2.3/reference/config.md
+++ b/docs/v2.3/reference/config.md
@@ -20,9 +20,6 @@ timeouts:
   intercept: 10s
 logLevels:
   userDaemon: debug
-images:
-  registry: privateRepo
-  agentImage: ambassador-telepresence-agent:1.8.0
 grpc:
   maxReceiveSize: 10Mi
 ```


### PR DESCRIPTION
Having privateRepo in the image settings causes traffic manager to be in ErrImageName state.