### PR TITLE
Make it clear not to use sample config

### DIFF
--- a/docs/pre-release/reference/config.md
+++ b/docs/pre-release/reference/config.md
@@ -12,7 +12,8 @@ For Linux, the above paths are for a user-level configuration. For system-level 
 
 The config file currently supports values for the `timeouts`, `logLevels`, `images`, `cloud`, and `grpc` keys.
 
-Here is an example configuration:
+Here is an example configuration to show you the conventions of how Telepresence is configured:
+**note: This config shouldn't be used verbatim, since the registry `privateRepo` used doesn't exist**
 
 ```yaml
 timeouts:
@@ -21,8 +22,8 @@ timeouts:
 logLevels:
   userDaemon: debug
 images:
-  registry: privateRepo
-  agentImage: ambassador-telepresence-agent:1.8.0
+  registry: privateRepo # This overrides the default docker.io/datawire repo
+  agentImage: ambassador-telepresence-agent:1.8.0 # This overrides the agent image to inject when intercepting
 grpc:
   maxReceiveSize: 10Mi
 ```

--- a/docs/v2.3/reference/config.md
+++ b/docs/v2.3/reference/config.md
@@ -12,7 +12,8 @@ For Linux, the above paths are for a user-level configuration. For system-level 
 
 The config file currently supports values for the `timeouts`, `logLevels`, `images`, `cloud`, and `grpc` keys.
 
-Here is an example configuration:
+Here is an example configuration to show you the conventions of how Telepresence is configured:
+**note: This config shouldn't be used verbatim, since the registry `privateRepo` used doesn't exist**
 
 ```yaml
 timeouts:
@@ -21,8 +22,8 @@ timeouts:
 logLevels:
   userDaemon: debug
 images:
-  registry: privateRepo
-  agentImage: ambassador-telepresence-agent:1.8.0
+  registry: privateRepo # This overrides the default docker.io/datawire repo
+  agentImage: ambassador-telepresence-agent:1.8.0 # This overrides the agent image to inject when intercepting
 grpc:
   maxReceiveSize: 10Mi
 ```

--- a/docs/v2.4/reference/config.md
+++ b/docs/v2.4/reference/config.md
@@ -12,7 +12,8 @@ For Linux, the above paths are for a user-level configuration. For system-level 
 
 The config file currently supports values for the `timeouts`, `logLevels`, `images`, `cloud`, and `grpc` keys.
 
-Here is an example configuration:
+Here is an example configuration to show you the conventions of how Telepresence is configured:
+**note: This config shouldn't be used verbatim, since the registry `privateRepo` used doesn't exist**
 
 ```yaml
 timeouts:
@@ -21,8 +22,8 @@ timeouts:
 logLevels:
   userDaemon: debug
 images:
-  registry: privateRepo
-  agentImage: ambassador-telepresence-agent:1.8.0
+  registry: privateRepo # This overrides the default docker.io/datawire repo
+  agentImage: ambassador-telepresence-agent:1.8.0 # This overrides the agent image to inject when intercepting
 grpc:
   maxReceiveSize: 10Mi
 ```


### PR DESCRIPTION
We include a sample configuration to show how users *might* configure Telepresence. It includes how you configure the registry, which won't work if users copy + paste the config onto their local machine, so adding a note to emphasize that it's just to show the convention of how config works and shouldn't actually be used, since it was a little misleading before.