### PR TITLE
Thallgren/relnotes 2.3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 # Other
 *.log
 .*.swp
+.idea

--- a/docs/pre-release/doc-links.yml
+++ b/docs/pre-release/doc-links.yml
@@ -34,8 +34,6 @@
    items:
      - title: Architecture
        link: reference/architecture
-     - title: Networking through Virtual Network Interface
-       link: reference/tun-device
      - title: Client reference
        link: reference/client
      - title: Laptop-side configuration
@@ -56,6 +54,10 @@
        link: reference/dns
      - title: RBAC
        link: reference/rbac
+     - title: Networking through Virtual Network Interface
+       link: reference/tun-device
+     - title: Connection Routing
+       link: reference/routing
      - title: Using Telepresence with Linkerd
        link: reference/linkerd
  - title: FAQs

--- a/docs/pre-release/releaseNotes.yml
+++ b/docs/pre-release/releaseNotes.yml
@@ -51,6 +51,12 @@ items:
           using it.
         docs: reference/routing#linux-systemd-resolved-resolver
 
+      - type: bugfix
+        title: Faster telepresence list command
+        body: The performance of <code>telepresence list</code> has been increased
+          significantly by reducing the number of calls the command makes to the cluster.
+        docs: reference/client
+
   - version: 2.3.6
     date: '2021-07-20'
     notes:

--- a/docs/pre-release/releaseNotes.yml
+++ b/docs/pre-release/releaseNotes.yml
@@ -43,6 +43,14 @@ items:
           <code>Empty reply from server</code> until you start a local process.
         docs: reference/intercepts
 
+      - type: bugfix
+        title: Improved DNS resolver for systemd-resolved
+        body: Telepresence's <code>systemd-resolved</code>-based DNS resolver is now more
+          stable and in case it fails to initialize, the <code>overriding resolver</code>
+          will no longer cause general DNS lookup failures when telepresence defaults to
+          using it.
+        docs: reference/routing#linux-systemd-resolved-resolver
+
   - version: 2.3.6
     date: '2021-07-20'
     notes:

--- a/docs/v2.3/doc-links.yml
+++ b/docs/v2.3/doc-links.yml
@@ -34,8 +34,6 @@
    items:
      - title: Architecture
        link: reference/architecture
-     - title: Networking through Virtual Network Interface
-       link: reference/tun-device
      - title: Client reference
        link: reference/client
      - title: Laptop-side configuration
@@ -56,6 +54,10 @@
        link: reference/dns
      - title: RBAC
        link: reference/rbac
+     - title: Networking through Virtual Network Interface
+       link: reference/tun-device
+     - title: Connection Routing
+       link: reference/routing
      - title: Using Telepresence with Linkerd
        link: reference/linkerd
  - title: FAQs

--- a/docs/v2.3/releaseNotes.yml
+++ b/docs/v2.3/releaseNotes.yml
@@ -51,6 +51,12 @@ items:
           using it.
         docs: reference/routing#linux-systemd-resolved-resolver
 
+      - type: bugfix
+        title: Faster telepresence list command
+        body: The performance of <code>telepresence list</code> has been increased
+          significantly by reducing the number of calls the command makes to the cluster.
+        docs: reference/client
+
   - version: 2.3.6
     date: '2021-07-20'
     notes:

--- a/docs/v2.3/releaseNotes.yml
+++ b/docs/v2.3/releaseNotes.yml
@@ -43,6 +43,14 @@ items:
           <code>Empty reply from server</code> until you start a local process.
         docs: reference/intercepts
 
+      - type: bugfix
+        title: Improved DNS resolver for systemd-resolved
+        body: Telepresence's <code>systemd-resolved</code>-based DNS resolver is now more
+          stable and in case it fails to initialize, the <code>overriding resolver</code>
+          will no longer cause general DNS lookup failures when telepresence defaults to
+          using it.
+        docs: reference/routing#linux-systemd-resolved-resolver
+
   - version: 2.3.6
     date: '2021-07-20'
     notes:


### PR DESCRIPTION
Release notes for improved `systemd-resolved`-based resolver and for the faster `telepresence list` command.