### PR TITLE
Fix option mount and docker-mount in migration guide

### DIFF
--- a/docs/v2.2/install/migrate-from-legacy.md
+++ b/docs/v2.2/install/migrate-from-legacy.md
@@ -61,7 +61,7 @@ are supported).
 | --run $cmd                                       | connect -- $cmd                            |
 | --env-file,--env-json                            | --env-file, --env-json (haven't changed)   |
 | --context,--namespace                            | --context, --namespace (haven't changed)   |
-| --mount,--docker-mount                           | --context, --namespace (haven't changed)   |
+| --mount,--docker-mount                           | --mount, --docker-mount (haven't changed)  |
 
 ### Legacy Telepresence command limitations
 

--- a/docs/v2.3/install/migrate-from-legacy.md
+++ b/docs/v2.3/install/migrate-from-legacy.md
@@ -61,7 +61,7 @@ are supported).
 | --run $cmd                                       | connect -- $cmd                            |
 | --env-file,--env-json                            | --env-file, --env-json (haven't changed)   |
 | --context,--namespace                            | --context, --namespace (haven't changed)   |
-| --mount,--docker-mount                           | --context, --namespace (haven't changed)   |
+| --mount,--docker-mount                           | --mount, --docker-mount (haven't changed)  |
 
 ### Legacy Telepresence command limitations
 

--- a/docs/v2.4/install/migrate-from-legacy.md
+++ b/docs/v2.4/install/migrate-from-legacy.md
@@ -73,7 +73,7 @@ are supported).
 | --run $cmd                                       | connect -- $cmd                            |
 | --env-file,--env-json                            | --env-file, --env-json (haven't changed)   |
 | --context,--namespace                            | --context, --namespace (haven't changed)   |
-| --mount,--docker-mount                           | --context, --namespace (haven't changed)   |
+| --mount,--docker-mount                           | --mount, --docker-mount (haven't changed)  |
 
 ### Legacy Telepresence command limitations
 


### PR DESCRIPTION
I think this was just a bad copy paste.

To be sure:

- [--mount](https://github.com/telepresenceio/telepresence/blob/404147caa2a58bd3a71bc0e863d179258c03d6f5/pkg/client/cli/cmds_intercept.go#L49) in v2
- [--docker-mount](https://github.com/telepresenceio/telepresence/blob/404147caa2a58bd3a71bc0e863d179258c03d6f5/pkg/client/cli/cmds_intercept.go#L54) in v2