### PR TITLE
Add nightly build for M1 Macs

### DIFF
--- a/docs/pre-release/install/index.md
+++ b/docs/pre-release/install/index.md
@@ -15,7 +15,7 @@ Follow one of our [quick start guides](../quick-start/) to start using Teleprese
 ## Installing nightly versions of Telepresence
 
 We build and publish the contents of the default branch, [release/v2](https://github.com/telepresenceio/telepresence), of Telepresence
-nightly, Monday through Friday.
+nightly, Monday through Friday, for macOS (Intel and M1 chips), Linux, and Windows.
 
 The tags are formatted like so: `vX.Y.Z-nightly-$gitShortHash`.
 

--- a/docs/pre-release/install/nightly-version-tabs.js
+++ b/docs/pre-release/install/nightly-version-tabs.js
@@ -70,7 +70,13 @@ export default function SimpleTabs() {
       <TabPanel value={value} index={0}>
         <CodeBlock>
         {
-          'https://app.getambassador.io/download/tel2/darwin/amd64/nightly/telepresence'
+          '# For Macs with Intel chip (X86)' +
+          '\n' +
+          'https://app.getambassador.io/download/tel2/darwin/amd64/nightly/telepresence' +
+          '\n \n' +
+          '# For Macs with M1 chip (ARM)' +
+          '\n' +
+          'https://app.getambassador.io/download/tel2/darwin/arm64/nightly/telepresence'
         }
         </CodeBlock>
       </TabPanel>

--- a/docs/v2.3/install/nightly-version-tabs.js
+++ b/docs/v2.3/install/nightly-version-tabs.js
@@ -70,7 +70,13 @@ export default function SimpleTabs() {
       <TabPanel value={value} index={0}>
         <CodeBlock>
         {
-          'https://app.getambassador.io/download/tel2/darwin/amd64/nightly/telepresence'
+          '# For Macs with Intel chip (X86)' +
+          '\n' +
+          'https://app.getambassador.io/download/tel2/darwin/amd64/nightly/telepresence' +
+          '\n \n' +
+          '# For Macs with M1 chip (ARM)' +
+          '\n' +
+          'https://app.getambassador.io/download/tel2/darwin/arm64/nightly/telepresence'
         }
         </CodeBlock>
       </TabPanel>

--- a/docs/v2.4/install/index.md
+++ b/docs/v2.4/install/index.md
@@ -15,7 +15,7 @@ Follow one of our [quick start guides](../quick-start/) to start using Teleprese
 ## Installing nightly versions of Telepresence
 
 We build and publish the contents of the default branch, [release/v2](https://github.com/telepresenceio/telepresence), of Telepresence
-nightly, Monday through Friday.
+nightly, Monday through Friday, for macOS (Intel and M1 chips), Linux, and Windows.
 
 The tags are formatted like so: `vX.Y.Z-nightly-$gitShortHash`.
 

--- a/docs/v2.4/install/nightly-version-tabs.js
+++ b/docs/v2.4/install/nightly-version-tabs.js
@@ -70,7 +70,13 @@ export default function SimpleTabs() {
       <TabPanel value={value} index={0}>
         <CodeBlock>
         {
-          'https://app.getambassador.io/download/tel2/darwin/amd64/nightly/telepresence'
+          '# For Macs with Intel chip (X86)' +
+          '\n' +
+          'https://app.getambassador.io/download/tel2/darwin/amd64/nightly/telepresence' +
+          '\n \n' +
+          '# For Macs with M1 chip (ARM)' +
+          '\n' +
+          'https://app.getambassador.io/download/tel2/darwin/arm64/nightly/telepresence'
         }
         </CodeBlock>
       </TabPanel>


### PR DESCRIPTION
Adding docs about how to install the Mac arm64 (M1 chip) nightly.