### PR TITLE
Fix the headings on /docs/v2.4/howtos/intercepts/

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,9 @@ module.exports = {
         gatsbyRemarkPlugins: [
           {
             resolve: 'gatsby-remark-autolink-headers',
+            options: {
+              enableCustomId: true,
+            },
           },
         ],
       },


### PR DESCRIPTION
I used a piece of markdown syntax that wasn't enabled.  Enable it.

Compare https://www.telepresence.io/docs/v2.4/howtos/intercepts/ to https://deploy-preview-78--telepresence.netlify.app/docs/v2.4/howtos/intercepts/