### PR TITLE
Bump main page release number from 2.4.0 to 2.4.3.

### DIFF
--- a/docs/pre-release/versions.yml
+++ b/docs/pre-release/versions.yml
@@ -1,4 +1,4 @@
-version: "2.4.0"
+version: "2.4.3"
 docsVersion: "pre-release"
 branch: release/v2
 productName: "Telepresence"

--- a/docs/v2.4/versions.yml
+++ b/docs/v2.4/versions.yml
@@ -1,4 +1,4 @@
-version: "2.4.0"
+version: "2.4.3"
 docsVersion: "2.4"
 branch: release/v2
 productName: "Telepresence"


### PR DESCRIPTION
Seems this was forgotten when we released the last 3 times.