### PR TITLE
Set the width of the VPN page by wrapping it in a div.

### DIFF
--- a/docs/pre-release/reference/vpn.md
+++ b/docs/pre-release/reference/vpn.md
@@ -1,3 +1,6 @@
+<!-- TODO: We should figure out a way to make this site-wide without affecting the release notes page -->
+<div class="container">
+
 # Telepresence and VPNs
 
 ## The test-vpn command
@@ -151,3 +154,4 @@ to use never-proxy rules to whitelist hosts in the VPN:
         * Move pod subnet 10.0.0.0/8 to a subnet not mapped by the VPN
                 * If this is not possible, ensure that any hosts in CIDR 0.0.0.0/1 are placed in the never-proxy list
 ```
+</div>

--- a/docs/v2.4/reference/vpn.md
+++ b/docs/v2.4/reference/vpn.md
@@ -1,3 +1,6 @@
+<!-- TODO: We should figure out a way to make this site-wide without affecting the release notes page -->
+<div class="container">
+
 # Telepresence and VPNs
 
 ## The test-vpn command
@@ -151,3 +154,4 @@ to use never-proxy rules to whitelist hosts in the VPN:
         * Move pod subnet 10.0.0.0/8 to a subnet not mapped by the VPN
                 * If this is not possible, ensure that any hosts in CIDR 0.0.0.0/1 are placed in the never-proxy list
 ```
+</div>


### PR DESCRIPTION
This is really not ideal, but that page in particular is very wide, so
this at least gets it working while we figure out a site-wide solution.

Signed-off-by: Jose Cortes <josecortes@datawire.io>