### PR TITLE
Update pull-docs to exclude dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,11 @@ dir2branch = $(patsubst docs/%,release/%,$(subst pre-release,v2,$1))
 
 # Used when syncing from telepresenceio since that repo doesn't
 # have docs for v1.
-EXCLUDE_DIR ?=
+EXCLUDE_DIR ?= ""
 pull-docs: ## Update ./docs from https://github.com/telepresenceio/docs
 pull-docs: subtree-preflight
-ifneq ($(EXCLUDE_DIR),)
 	$(foreach subdir,$(shell find docs -mindepth 1 -maxdepth 1 -type d -not -name $(EXCLUDE_DIR)|sort -V),\
           git subtree pull --squash --prefix=$(subdir) https://github.com/telepresenceio/docs $(PULL_PREFIX)$(call dir2branch,$(subdir))$(nl))
-else
-	$(foreach subdir,$(shell find docs -mindepth 1 -maxdepth 1 -type d|sort -V),\
-          git subtree pull --squash --prefix=$(subdir) https://github.com/telepresenceio/docs $(PULL_PREFIX)$(call dir2branch,$(subdir))$(nl))
-endif
 .PHONY: pull-docs
 
 PUSH_BRANCH ?= $(USER)/from-telepresence.io-$(shell date +%Y-%m-%d)

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,18 @@ PUSH_PREFIX ?= $(USER)/from-telepresence.io-$(shell date +%Y-%m-%d)/
 
 dir2branch = $(patsubst docs/%,release/%,$(subst pre-release,v2,$1))
 
+# Used when syncing from telepresenceio since that repo doesn't
+# have docs for v1.
+EXCLUDE_DIR ?=
 pull-docs: ## Update ./docs from https://github.com/telepresenceio/docs
 pull-docs: subtree-preflight
+ifneq ($(EXCLUDE_DIR),)
+	$(foreach subdir,$(shell find docs -mindepth 1 -maxdepth 1 -type d -not -name $(EXCLUDE_DIR)|sort -V),\
+          git subtree pull --squash --prefix=$(subdir) https://github.com/telepresenceio/docs $(PULL_PREFIX)$(call dir2branch,$(subdir))$(nl))
+else
 	$(foreach subdir,$(shell find docs -mindepth 1 -maxdepth 1 -type d|sort -V),\
           git subtree pull --squash --prefix=$(subdir) https://github.com/telepresenceio/docs $(PULL_PREFIX)$(call dir2branch,$(subdir))$(nl))
+endif
 .PHONY: pull-docs
 
 PUSH_BRANCH ?= $(USER)/from-telepresence.io-$(shell date +%Y-%m-%d)


### PR DESCRIPTION
When pulling docs from the telepresence repo, there are no v1 docs, so
we've updated the make pull-docs command so you can exclude docs
directories that you don't want to sync, mainly v1 in this case.

Running would look like:
```
EXCLUDE_DIR=v1 make pull-docs
```

Signed-off-by: Donny Yung <donaldyung@datawire.io>