### PR TITLE
Create redirects for telepresence

### DIFF
--- a/docs/v2.3/quick-start/TelepresenceQuickStartLanding.js
+++ b/docs/v2.3/quick-start/TelepresenceQuickStartLanding.js
@@ -51,7 +51,7 @@ const TelepresenceQuickStartLanding = () => (
             See how changes to a single service impact your entire application
             without having to run your entire app locally.
           </p>
-          <a className="get-started blue" href="demo-node/">
+          <a className="get-started blue" href="https://www.getambassador.io/docs/telepresence/latest/quick-start/">
             GET STARTED{' '}
             <RightArrow width={20} height={20} fill="currentColor" />
           </a>
@@ -63,7 +63,7 @@ const TelepresenceQuickStartLanding = () => (
             Make changes to your service locally and see the results instantly,
             without waiting for containers to build.
           </p>
-          <a className="get-started blue" href="go/">
+          <a className="get-started blue" href="https://www.getambassador.io/docs/code/latest/quick-start/qs-go/">
             GET STARTED{' '}
             <RightArrow width={20} height={20} fill="currentColor" />
           </a>
@@ -86,7 +86,7 @@ const TelepresenceQuickStartLanding = () => (
             Query services only exposed in your cluster's network. Make changes
             and see them instantly in your K8s environment.
           </p>
-          <a className="get-started green" href="../howtos/intercepts/">
+          <a className="get-started green" href="https://www.getambassador.io/docs/telepresence/latest/howtos/intercepts/">
             GET STARTED{' '}
             <RightArrow width={20} height={20} fill="currentColor" />
           </a>

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -120,27 +120,36 @@ exports.createPages = async ({ graphql, actions }) => {
 
     const urlpath = docsConfig.urlpath(node);
 
-    actions.createPage({
-      // URL-path to create the page at
-      path: urlpath,
-      // Absolute filepath of the component to render the page with
-      component: path.resolve('./src/templates/doc-page.js'),
-      // Arguments to pass to that component's `query`
-      context: {
-        contentFileNodeID:   node.id,
-        variablesFileNodeID: variablesCache[variablesFilepath],
-        sidebarFileNodeID:   sidebarCache[sidebarFilepath],
-        docinfo: {
-          docrootURL:   docsConfig.docrootURL(node),
-          canonicalURL: docsConfig.canonicalURL(node),
-          githubURL:    docsConfig.githubURL(node),
-
-          maybeShowReadingTime: docsConfig.maybeShowReadingTime(node),
-
-          peerVersions: docsConfig.peerVersions(urlpath, allURLPaths),
+    if (urlpath === '/docs/latest/quick-start/') {
+      actions.createPage({
+        // URL-path to create the page at
+        path: urlpath,
+        // Absolute filepath of the component to render the page with
+        component: path.resolve('./src/templates/doc-page.js'),
+        // Arguments to pass to that component's `query`
+        context: {
+          contentFileNodeID:   node.id,
+          variablesFileNodeID: variablesCache[variablesFilepath],
+          sidebarFileNodeID:   sidebarCache[sidebarFilepath],
+          docinfo: {
+            docrootURL:   docsConfig.docrootURL(node),
+            canonicalURL: docsConfig.canonicalURL(node),
+            githubURL:    docsConfig.githubURL(node),
+  
+            maybeShowReadingTime: docsConfig.maybeShowReadingTime(node),
+  
+            peerVersions: docsConfig.peerVersions(urlpath, allURLPaths),
+          },
         },
-      },
-    });
+      });
+    } else {
+      actions.createRedirect({
+        fromPath: urlpath,
+        toPath: '/docs/latest/quick-start/',
+        redirectInBrowser: true,
+        isPermanent: true,
+      });
+    }
   }
 
   // Create up redirects

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -3,7 +3,7 @@ import '../Layout/layout.less';
 
 const LINKS = [
 	{ label: 'Quick Start', link: '/docs/latest/quick-start/' },
-	{ label: 'Docs', link: '/docs/latest/' },
+	{ label: 'Docs', link: 'https://www.getambassador.io/docs/telepresence/' },
 	{ label: 'Case Studies', link: '/case-studies' },
 	{ label: 'Community', link: '/community' },
 	{ label: 'About', link: '/about' },

--- a/src/templates/doc-page.less
+++ b/src/templates/doc-page.less
@@ -1,18 +1,10 @@
 .docs {
-    display: grid;
-    grid-template-columns: 300px auto;
+    margin-top: 4rem;
+    display: flex;
+    flex-direction: column;
+    grid-template-columns: auto;
     grid-template-rows: auto min-content;
     &__sidebar {
-        grid-column: 1;
-        grid-row-start: 1;
-        grid-row-end: 3;
-    }
-    &__main {
-        grid-column: 2;
-        grid-row: 1;
-    }
-    &__footer {
-        grid-column: 2;
-        grid-row: 2;
+        display: none;
     }
 }


### PR DESCRIPTION
1. Almost  doc pages was moved to redirect pointing to https://deploy-preview-174--telepresence.netlify.app//docs/latest/quick-start/
2. The main header doc link now is pointing to ambassador.
3. We remove the aside navigation in quick start page.


<img width="1369" alt="Screen Shot 2022-10-12 at 8 56 59" src="https://user-images.githubusercontent.com/101214760/195362642-9f24ae9c-0e8e-4772-898b-47e954dd6f80.png">


Signed-off-by: Leonel Contreras <lcontreras@datawire.io>