### PR TITLE
Revert upgrade to Telpresence 2.17.1. There's no such release.

### DIFF
--- a/docs/latest/versions.yml
+++ b/docs/latest/versions.yml
@@ -1,5 +1,5 @@
-version: "2.17.1"
-dlVersion: "v2.17.1"
+version: "2.17.0"
+dlVersion: "v2.17.0"
 docsVersion: "2.15"
 branch: release/v2
 productName: "Telepresence OSS"


### PR DESCRIPTION
Closes telepresenceio/telepresence#3485