### PR TITLE
Add trademark message to other pages

### DIFF
--- a/src/components/CaseStudyTemplate/CaseStudyTemplate.js
+++ b/src/components/CaseStudyTemplate/CaseStudyTemplate.js
@@ -62,15 +62,24 @@ const CaseStudyTemplate = ({ caseStudy, children }) => {
 					{children}
 				</div>
 			</section>
-			<section className={classnames('purpleBackground', 'caseStudyFooter')}>
-				<h4>Questions?</h4>
-				<p>Let us help you get started</p>
-				<a className="btn-purple-light" href="/docs/latest/quick-start/">
-					get started
-				</a>
-			</section>
-		</>
-	);
+      <section className={classnames('purpleBackground', 'caseStudyFooter')}>
+        <h4>Questions?</h4>
+        <p>Let us help you get started</p>
+        <a className="btn-purple-light" href="/docs/latest/quick-start/">
+          get started
+        </a>
+        <div className="trademarkUsage">
+          <p>
+            The Linux Foundation has registered trademarks and uses trademarks.
+            For a list of trademarks of The Linux Foundation,
+            please see our <a
+            href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark
+            Usage page</a>.
+          </p>
+        </div>
+      </section>
+    </>
+  );
 };
 
 export default CaseStudyTemplate;

--- a/src/components/CaseStudyTemplate/style.less
+++ b/src/components/CaseStudyTemplate/style.less
@@ -211,4 +211,8 @@
 		padding-top: 5.625rem;
 		padding-bottom: 5.625rem;
 	}
+
+    .trademarkUsage {
+        margin-top: 5rem;
+    }
 }

--- a/src/components/Layout/docs-layout.less
+++ b/src/components/Layout/docs-layout.less
@@ -754,5 +754,15 @@
 			justify-content: flex-end;
 			text-decoration: underline;
 		}
+
+        .trademarkUsage {
+            margin-top: 2rem;
+            display: flex;
+            justify-content: center;
+
+            a {
+                display: inline-block;
+            }
+        }
 	}
 }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -44,19 +44,29 @@ export default function AboutPage({ location }) {
 					/>
 				</div>
 			</section>
-			<section className="aboutPageStayUpdated">
-				<h4>Stay Updated</h4>
-				<p>
-					Telepresence is under active development. Subscribe to get updates and
-					announcements:
-				</p>
-				<div className="aboutPageHubspotForm">
-					<HubspotForm
-						portalId="485087"
-						formId="956287a4-7614-486b-91bd-28c9a91949cb"
-					/>
-				</div>
-			</section>
-		</EasyLayout>
-	);
+      <section className="aboutPageStayUpdated">
+        <h4>Stay Updated</h4>
+        <p>
+          Telepresence is under active development. Subscribe to get updates and
+          announcements:
+        </p>
+        <div className="aboutPageHubspotForm">
+          <HubspotForm
+            portalId="485087"
+            formId="956287a4-7614-486b-91bd-28c9a91949cb"
+          />
+        </div>
+        <div className="trademarkUsage">
+          <p>
+            The Linux Foundation has registered trademarks and uses
+            trademarks.
+            For a list of trademarks of The Linux Foundation,
+            please see our <a
+            href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark
+            Usage page</a>.
+          </p>
+        </div>
+      </section>
+    </EasyLayout>
+  );
 }

--- a/src/pages/case-studies/index.js
+++ b/src/pages/case-studies/index.js
@@ -58,20 +58,31 @@ export default function CaseStudiesPage({ location }) {
 					))}
 				</div>
 			</section>
-			<section
-				className={classnames('caseStudiesPageSection', 'purpleBackground')}
-			>
-				<div className="caseStudiesPageSection-contact">
-					<h4>Have a Telepresence story to share?</h4>
-					<p>Tell us your story</p>
-					<a
-						className="btn-purple-light"
-						href="https://www.getambassador.io/contact-us/"
-					>
-						contact us
-					</a>
-				</div>
-			</section>
-		</EasyLayout>
-	);
+      <section
+        className={classnames('caseStudiesPageSection', 'purpleBackground')}
+      >
+        <div className="caseStudiesPageSection-contact">
+          <h4>Have a Telepresence story to share?</h4>
+          <p>Tell us your story</p>
+          <a
+            className="btn-purple-light"
+            href="https://www.getambassador.io/contact-us/"
+          >
+            contact us
+          </a>
+          <div className="trademarkUsage">
+            <p>
+              The Linux Foundation has registered trademarks and uses
+              trademarks.
+              For a list of trademarks of The Linux Foundation,
+              please see our <a
+              href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark
+              Usage page</a>.
+            </p>
+          </div>
+        </div>
+
+      </section>
+    </EasyLayout>
+  );
 }

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -88,18 +88,28 @@ export default function CommunityPage({ location }) {
 					</div>
 				</div>
 			</section>
-			<section className="communityPageSection purpleLight">
-				<div className="communityPageSection-socialCards">
-					<h2 className="communityPageSection-exploreTitle">
-						Explore and Contribute to Our Networks
-					</h2>
-					<div className="communityPageSection-socialCards-container">
-						{SOCIAL_CARDS.map((card, index) => (
-							<SocialCard key={index} {...card} />
-						))}
-					</div>
-				</div>
-			</section>
-		</EasyLayout>
-	);
+      <section className="communityPageSection purpleLight">
+        <div className="communityPageSection-socialCards">
+          <h2 className="communityPageSection-exploreTitle">
+            Explore and Contribute to Our Networks
+          </h2>
+          <div className="communityPageSection-socialCards-container">
+            {SOCIAL_CARDS.map((card, index) => (
+              <SocialCard key={index} {...card} />
+            ))}
+          </div>
+          <div className="trademarkUsage">
+            <p>
+              The Linux Foundation has registered trademarks and uses
+              trademarks.
+              For a list of trademarks of The Linux Foundation,
+              please see our <a
+              href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark
+              Usage page</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+    </EasyLayout>
+  );
 }

--- a/src/templates/doc-page.js
+++ b/src/templates/doc-page.js
@@ -134,10 +134,22 @@ export default function DocPage({ location, data, pageContext }) {
           </div>
         </main>
         <footer className="docs__footer">
-          <a href={pageContext.docinfo.githubURL} className="github" target="_blank" rel="noreferrer">
-              <GithubIcon />
+          <div>
+            <a href={pageContext.docinfo.githubURL} className="github"
+               target="_blank" rel="noreferrer">
+              <GithubIcon/>
               Edit this page on GitHub
-          </a>
+            </a>
+          </div>
+          <div className="trademarkUsage">
+            <p>
+              The Linux Foundation has registered trademarks and uses
+              trademarks. For a list of trademarks of The Linux Foundation,
+              please see our <a
+              href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark
+              Usage page</a>.
+            </p>
+          </div>
         </footer>
       </div>
     </Layout>


### PR DESCRIPTION
## Description
Adds the Linux Foundation trademark message to the footer of the About, Case Study, Community, and Quickstart pages to be in compliance with new guidelines.

## Before
### About
![Screen Shot 2024-02-14 at 1 18 40 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/2d52cc0d-e44d-41e5-9ebf-c8033fc9d63a)

### Case Study
![Screen Shot 2024-02-14 at 1 19 06 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/e3e9d5e5-59c2-48fe-8f70-d4b33db1279b)

![Screen Shot 2024-02-14 at 1 20 03 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/e892e776-8ccc-4b3a-b2d2-0a2f6a86a96f)

### Community
![Screen Shot 2024-02-14 at 1 20 30 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/ab2bf0f5-8735-412f-98b9-15991dbe13cd)

### Quickstart
![Screen Shot 2024-02-14 at 1 21 06 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/2ab40e04-10f5-4793-adda-4c8998583b0b)

## After
### About
![Screen Shot 2024-02-14 at 1 22 38 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/5d40bea7-8787-4a6b-85f8-aa452b32fc05)

### Case Study
![Screen Shot 2024-02-14 at 1 23 05 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/151749cd-065d-4f9b-b329-71c74c179505)

### Community
![Screen Shot 2024-02-14 at 1 23 31 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/291d1ef3-7954-46b7-938c-eafa082a7a12)

### Quickstart
![Screen Shot 2024-02-14 at 1 24 00 PM](https://github.com/telepresenceio/telepresence.io/assets/987830/e2f12ae8-b7ba-44aa-b3aa-4e62414fd987)
