### PR TITLE
Fix shell copy

### DIFF
--- a/docs/v2.5/quick-start/index.md
+++ b/docs/v2.5/quick-start/index.md
@@ -36,7 +36,9 @@ sudo curl -fL https://app.getambassador.io/download/tel2oss/releases/download/$d
 
 # 2. Make the binary executable:
 sudo chmod a+x /usr/local/bin/telepresence
+```
 
+```shell
 # Apple silicon Macs
 
 # 1. Download the latest binary (~101 MB):


### PR DESCRIPTION
This would provide better experience to copy commands for specific architecture. Right now the default copy option copies commands for both architecture