### PR TITLE
Fix button href in HomePage component for consistency

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,7 +24,7 @@ const HomePage: React.FC = () => {
 	const getStarted = (
 		<Button
 			variant="contained"
-			href={`/docs/quick-start/`}
+			href={`/docs/quick-start`}
 			sx={{
 				marginY: "4em",
 				lineHeight: "2.5",


### PR DESCRIPTION
Fix broken architecture link from quick-start page
Problem
The architecture link from the quick-start page breaks when accessed from URLs with trailing slashes, resulting in 404 errors.
Root Cause
Relative links behave differently depending on whether the current URL has a trailing slash - the browser resolves them relative to different base paths.
Solution
Update the relative link path to ensure consistent resolution behavior regardless of trailing slashes.
Impact
Fixes broken navigation from quick-start to architecture documentation
Ensures the link works reliably for all users
Improves overall documentation UX

long story short , I was reading the documentation and seen that architecture hrefs doesn't work if you came from
https://telepresence.io/docs/quick-start/

fixed at telepresenceio-homepage repo and telepresence main repo.