### PR TITLE
Replace getambassador.io Argo link with argoproj Argo Rollouts

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -29,8 +29,7 @@ const AboutPage: React.FC = () => {
 						connecting that service to a remote Kubernetes cluster.
 					</Paragraph>
 					<Paragraph>
-						Telepresence is a CNCF sandbox tool initially built by the team at{' '}
-						<a href="https://www.getambassador.io/">Ambassador</a>, the creators
+						Telepresence is a CNCF sandbox tool initially built by the team at Ambassador, the creators
 						of Emissary-ingress (Kubernetes-native API gateway powered by Envoy Proxy).
 					</Paragraph>
 					<Paragraph>

--- a/src/pages/case-studies/index.tsx
+++ b/src/pages/case-studies/index.tsx
@@ -103,9 +103,9 @@ const CaseStudiesPage: React.FC = () => {
 						Have a Telepresence story to share?
 					</Typography>
 					<Typography fontWeight={"bold"} variant='body1' component="p" padding="1em 0 2em">
-						Tell us your story
+						Tell us your story on the #telepresence-oss channel
 					</Typography>
-					<Button variant="contained" href="https://www.getambassador.io/contact-us/">contact us</Button>
+					<Button variant="contained" href="https://slack.cncf.io">contact us</Button>
 				</Grid>
 			</Grid>
 		</Layout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -87,7 +87,7 @@ const HomePage: React.FC = () => {
 						<Typography variant="body2">
 							Telepresence is
 							a {link("Cloud Native Computing Foundation", "https://www.cncf.io/")} Sandbox
-							project initially created by the team at {link("Ambassador", "https://www.getambassador.io/")}
+							project initially created by the team at Ambassador.
 						</Typography>
 					</Box>
 				</Grid>
@@ -106,9 +106,9 @@ const HomePage: React.FC = () => {
 						Speed Up Your Inner Dev Loop
 					</Typography>
 					<Typography variant='body1' component="p">
-						Kubernetes should make your team faster. 
-						But every time you make a code change, you have to wait for containers to build, be pushed to a registry and deployed. 
-						With Telepresence, you develop as if everything runs on your machine. 
+						Kubernetes should make your team faster.
+						But every time you make a code change, you have to wait for containers to build, be pushed to a registry and deployed.
+						With Telepresence, you develop as if everything runs on your machine.
 						No need to manage dependencies. Code, test, and see results immediately.
 					</Typography>
 				</Grid>
@@ -120,8 +120,8 @@ const HomePage: React.FC = () => {
 					<Typography variant='body1' component="p">
 						You want to catch errors before they reach production.
 						To do this, you need a realistic development environment.
-						However, Kubernetes environments can be costly. 
-						Telepresence solves this by letting you connect your local service to remote dependencies. 
+						However, Kubernetes environments can be costly.
+						Telepresence solves this by letting you connect your local service to remote dependencies.
 						This allows you to test as if your laptop is part of the cluster.
 					</Typography>
 				</Grid>
@@ -131,8 +131,8 @@ const HomePage: React.FC = () => {
 						Use Your Existing Workflow
 					</Typography>
 					<Typography variant='body1' component="p">
-						Missing your favorite code editor, debugger, or profiler? 
-						You can use anything that runs on your laptop with Telepresence. 
+						Missing your favorite code editor, debugger, or profiler?
+						You can use anything that runs on your laptop with Telepresence.
 						This includes services running in Kubernetes.
 					</Typography>
 				</Grid>

--- a/versioned_docs/version-2.29/reference/engagements/cli.md
+++ b/versioned_docs/version-2.29/reference/engagements/cli.md
@@ -81,7 +81,7 @@ Oftentimes, there's a 1-to-1 relationship between a service and a
 workload, so telepresence is able to auto-detect which service it
 should intercept based on the workload you are trying to intercept.
 But if you use something like
-[Argo](https://www.getambassador.io/docs/argo/latest/), there may be
+[Argo Rollouts](https://argoproj.github.io/argo-rollouts/), there may be
 two services (that use the same labels) to manage traffic between a
 canary and a stable service.
 


### PR DESCRIPTION
The `getambassador.io` Argo docs link in the CLI engagements reference is no longer relevant to Telepresence. This points the example at the canonical CNCF/argoproj Argo Rollouts documentation instead, which is also a more accurate target since the surrounding text describes Argo Rollouts' canary/stable service pattern.