### PR TITLE
Surface GitHub Discussions alongside Slack, listed first

### DIFF
--- a/blog/2025-10-16-telepresence-2.25.md
+++ b/blog/2025-10-16-telepresence-2.25.md
@@ -149,4 +149,4 @@ Combining HTTP-filtered intercepts with TLS/mTLS support means you can debug sec
 
 For more details, check out our docs on [intercepting applications](/docs/2.26/howtos/engage#intercept-your-application) and [TLS/mTLS handling](/docs/2.26/howtos/mtls).
 
-Ready to try it? Upgrade to Telepresence 2.25.0 today and intercept smarter. We'd love to hear your feedback—drop us a line or join the community discussions!
+Ready to try it? Upgrade to Telepresence 2.25.0 today and intercept smarter. We'd love to hear your feedback—drop us a line or join the [community discussions](https://github.com/telepresenceio/telepresence/discussions)!

--- a/blog/2026-02-28-telepresence-2.27.md
+++ b/blog/2026-02-28-telepresence-2.27.md
@@ -91,4 +91,4 @@ Upgrade to Telepresence 2.27.0 and leave `sudo` behind. If you're coming from a 
 
 Check out the [install guide](/docs/install/client) for platform-specific instructions and the full [release notes](/docs/release-notes) for details.
 
-We'd love your feedback -- open an issue on [GitHub](https://github.com/telepresenceio/telepresence/issues) or join the conversation in the community.
+We'd love your feedback -- open an issue on [GitHub](https://github.com/telepresenceio/telepresence/issues) or join the conversation in [GitHub Discussions](https://github.com/telepresenceio/telepresence/discussions).

--- a/blog/2026-05-11-telepresence-2.28.md
+++ b/blog/2026-05-11-telepresence-2.28.md
@@ -156,4 +156,4 @@ included in this release.
 
 We'd love your feedback. Open an issue on
 [GitHub](https://github.com/telepresenceio/telepresence/issues) or join the
-conversation in the community.
+conversation in [GitHub Discussions](https://github.com/telepresenceio/telepresence/discussions).

--- a/blog/2026-06-20-telepresence-2.29.md
+++ b/blog/2026-06-20-telepresence-2.29.md
@@ -185,4 +185,4 @@ feature, change, and fix in this release.
 
 We'd love your feedback. Open an issue on
 [GitHub](https://github.com/telepresenceio/telepresence/issues) or join the
-conversation in the community.
+conversation in [GitHub Discussions](https://github.com/telepresenceio/telepresence/discussions).

--- a/blog/2026-07-14-telepresence-2.30.md
+++ b/blog/2026-07-14-telepresence-2.30.md
@@ -101,5 +101,6 @@ node-agent, and this release is the result. Thank you.
 The [quick start](/docs/quick-start) takes about ten minutes. The full list
 of changes in 2.30.0 is in the
 [release notes](/docs/release-notes). Questions and war stories are welcome
-in [#telepresence-oss](https://cloud-native.slack.com/archives/C06B36KJ85P)
-on the CNCF Slack.
+in [GitHub Discussions](https://github.com/telepresenceio/telepresence/discussions)
+or [#telepresence-oss](https://cloud-native.slack.com/archives/C06B36KJ85P) on the
+CNCF Slack.

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -46,8 +46,9 @@ const AboutPage: React.FC = () => {
 					<Paragraph>
 						We welcome all community contributions. If you find a bug or a
 						mistake in the documentation, you can help us out by submitting an
-						issue or a pull request with a fix. If you have questions, join our
-						active <a href="https://slack.cncf.io/">Slack community</a>.
+						issue or a pull request with a fix. If you have questions, ask in
+						<a href="https://github.com/telepresenceio/telepresence/discussions">GitHub Discussions</a> or
+						join our active <a href="https://slack.cncf.io/">Slack community</a>.
 					</Paragraph>
 				</Grid>
 				<Grid size={{xs: 8, md: 5}} offset={{xs: 2, md: 0}} sx={{

--- a/src/pages/case-studies/index.tsx
+++ b/src/pages/case-studies/index.tsx
@@ -135,9 +135,10 @@ const CaseStudiesPage: React.FC = () => {
                             fontWeight: "bold",
                             padding: "1em 0 2em"
                         }}>
-						Tell us your story on the #telepresence-oss channel
+						Tell us your story in GitHub Discussions or the #telepresence-oss channel
 					</Typography>
-					<Button variant="contained" href="https://slack.cncf.io">contact us</Button>
+					<Button variant="contained" href="https://github.com/telepresenceio/telepresence/discussions">share your story</Button>
+					<Button variant="outlined" href="https://slack.cncf.io" sx={{ml: 2}}>CNCF Slack</Button>
 				</Grid>
 			</Grid>
         </Layout>

--- a/src/pages/case-studies/iris-tv.tsx
+++ b/src/pages/case-studies/iris-tv.tsx
@@ -51,6 +51,7 @@ const IrisPage: React.FC = () => {
 					reflecting on it, and refining it. Testing your workflow with a small
 					set of users, and incrementally rolling it out is a good strategy.
 					Also,{' '}
+					<a href="https://github.com/telepresenceio/telepresence/discussions">ask the community in GitHub Discussions</a>, or{' '}
 					<a href="https://slack.cncf.io/">talk with the team behind Telepresence</a>{' '}
 					on their #telepresence-oss Slack chat; they can provide good advice and perspective.
 				</p>

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import SlackLogo from '../assets/images/slack-logo.svg';
 import GithubLogo from '../assets/images/github-logo.svg';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import Typography from "@mui/material/Typography";
 
 import Grid from "@mui/material/Grid";
@@ -9,6 +10,13 @@ import {Card, CardActionArea, CardContent, Theme} from "@mui/material";
 import Layout from "../components/Layout";
 
 const SOCIAL_CARDS = [
+	{
+		logo: (<ForumOutlinedIcon sx={{fontSize: 48}}/>),
+		title: 'GitHub Discussions',
+		link: 'https://github.com/telepresenceio/telepresence/discussions',
+		description:
+			'Ask questions, share ideas, and help shape the roadmap — right where the code lives.',
+	},
 	{
 		logo: (<SlackLogo height={48} width={48}/>),
 		title: 'Slack',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -224,8 +224,8 @@ const HomePage: React.FC = () => {
 					<Typography variant="body1">
 						To find out more about the Telepresence Architecture, check out
 						the {link("docs", `/docs/concepts/architecture/`)} or
-						join us in the #telepresence-oss channel on
-						the {link("CNCF Slack", "https://slack.cncf.io/")}.
+						join the conversation in {link("GitHub Discussions", "https://github.com/telepresenceio/telepresence/discussions")}
+						or the #telepresence-oss channel on the {link("CNCF Slack", "https://slack.cncf.io/")}.
 					</Typography>
 					{getStarted}
 				</Grid>

--- a/versioned_docs/version-2.30/faqs.md
+++ b/versioned_docs/version-2.30/faqs.md
@@ -97,4 +97,4 @@ Yes, it is! You'll find both source code and documentation in the [Telepresence 
 
 #### How do I share my feedback on Telepresence?
 
-Your feedback is always appreciated and helps us build a product that provides as much value as possible for our community. You can chat with us directly on our #telepresence-oss channel at the [CNCF Slack](https://slack.cncf.io), and also report issues or create pull-requests on the GitHub repository.
+Your feedback is always appreciated and helps us build a product that provides as much value as possible for our community. You can ask questions and share ideas in [GitHub Discussions](https://github.com/telepresenceio/telepresence/discussions), chat with us on our #telepresence-oss channel at the [CNCF Slack](https://slack.cncf.io), and also report issues or create pull-requests on the GitHub repository.


### PR DESCRIPTION
Adds **GitHub Discussions** as a community channel everywhere the site links to the CNCF Slack (or points at "the community"), and gives it top billing — listed before Slack.

## Site pages
- **Community page** — new GitHub Discussions card (forum icon), placed first, ahead of the Slack card.
- **Homepage** — "join the conversation in GitHub Discussions or the #telepresence-oss channel on the CNCF Slack".
- **About page** — "ask in GitHub Discussions or join our active Slack community".
- **Case studies (index)** — primary "share your story" button now points to Discussions; the CNCF Slack becomes a secondary button.
- **Case study (IRIS.TV)** — adds a Discussions link before the existing Slack link.

## Blog posts
- Added a GitHub Discussions link to the community/feedback CTA in the **2.25, 2.27, 2.28, 2.29, and 2.30** release posts (ahead of the CNCF Slack in 2.30, where both appear).

## Why
GitHub Discussions has far lower entry friction than the CNCF Slack workspace (which needs a separate sign-up), it's where the code, issues, and releases already live, and its threads are search-indexed so answers compound over time.

## Not included
- A customer quote in the Verloop case study that mentions Slack in passing, and a generic "feedback on GitHub!" line in the 2.24 post (no community-channel link).
- The docs pages (`faqs`, `troubleshooting`, `install/*`, `reference/cluster-config`) that mention the CNCF Slack — those are generated from the telepresence repo's `docs/` source, so they'll be handled there and regenerated separately.

Site builds clean locally (`yarn build`).