### PR TITLE
Regenerate 2.30 community page from release/v2

### DIFF
--- a/versioned_docs/version-2.30/community.md
+++ b/versioned_docs/version-2.30/community.md
@@ -9,5 +9,5 @@ hide_table_of_contents: true
 Please review our [contributor's guide](https://github.com/telepresenceio/telepresence/blob/release/v2/CONTRIBUTING.md)
 on GitHub to learn how you can help make Telepresence better.
 
-## Meetings
-Check out our community [meeting schedule](https://github.com/telepresenceio/telepresence/blob/release/v2/MEETING_SCHEDULE.md) for opportunities to interact with Telepresence developers.
+## Get involved
+Visit the [Telepresence home page](https://telepresence.io/) to connect with the community.


### PR DESCRIPTION
Regenerates the version-2.30 docs to pick up the community-page fix merged to `release/v2` in telepresenceio/telepresence (commit `fb8d82b7e`): the stale "Meetings" section (we hold no community meetings) is replaced with a pointer to the Telepresence home page.

Only `versioned_docs/version-2.30/community.md` changes. Site builds clean locally (`yarn build`).