### PR TITLE
Regenerate 2.30 release notes

### DIFF
--- a/versioned_docs/version-2.30/release-notes.md
+++ b/versioned_docs/version-2.30/release-notes.md
@@ -8,12 +8,6 @@
 Installing the traffic-manager with <code>nodeAgent.enabled=true</code> now also makes the node-agent the default mode for client attachments; previously the client-side default had to be enabled separately through the Helm chart's <code>client.nodeAgent.enabled</code> value. An explicitly set <code>client.nodeAgent.enabled</code> always wins, so administrators can keep the sidecar as the default while still allowing node-agent attachments by setting it to <code>false</code>.
 </div>
 
-## <div style="display:flex;"><img src="images/change.png" alt="change" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">The traffic-manager reports node-agent and agent-injector enablement</div></div>
-<div style="margin-left: 15px">
-
-The traffic-manager's anonymous usage report now records whether node-agent mode and the agent-injector are enabled, so adoption of the agent modes can be measured.
-</div>
-
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Ports forwarded with --to-pod bind the loopback interface only</div></div>
 <div style="margin-left: 15px">
 

--- a/versioned_docs/version-2.30/release-notes.mdx
+++ b/versioned_docs/version-2.30/release-notes.mdx
@@ -15,12 +15,6 @@ Installing the traffic-manager with <code>nodeAgent.enabled=true</code> now also
   </Body>
 </Note>
 <Note>
-	<Title type="change">The traffic-manager reports node-agent and agent-injector enablement</Title>
-	<Body>
-The traffic-manager's anonymous usage report now records whether node-agent mode and the agent-injector are enabled, so adoption of the agent modes can be measured.
-  </Body>
-</Note>
-<Note>
 	<Title type="bugfix">Ports forwarded with --to-pod bind the loopback interface only</Title>
 	<Body>
 The local listeners created for <code>--to-pod</code> ports bound all workstation interfaces, exposing the forwarded pod ports to the local network. They now bind the loopback interface, matching the flag's documented <code>localhost:PORT</code> contract. A containerized daemon is unaffected: its listeners stay on all interfaces of the daemon container's private network namespace, which docker port publishing requires.


### PR DESCRIPTION
Re-run of `make generate-version` DOCS_VERSION=2.30 against the current release branch.