### PR TITLE
Correct advisory severity in the 2.31 blog post

### DIFF
--- a/blog/2026-07-22-telepresence-2.31.md
+++ b/blog/2026-07-22-telepresence-2.31.md
@@ -14,7 +14,7 @@ proving who they were. Two advisories,
 [GHSA-j8j4-rw65-56r6](https://github.com/telepresenceio/telepresence/security/advisories/GHSA-j8j4-rw65-56r6)
 (High) and
 [GHSA-6j3h-rp73-6rvf](https://github.com/telepresenceio/telepresence/security/advisories/GHSA-6j3h-rp73-6rvf)
-(Medium), describe what that made possible. This release closes both, and we
+(High), describe what that made possible. This release closes both, and we
 recommend upgrading.
 
 <!-- truncate -->


### PR DESCRIPTION
The 2.31.0 release blog post labels [GHSA-6j3h-rp73-6rvf](https://github.com/telepresenceio/telepresence/security/advisories/GHSA-6j3h-rp73-6rvf) as Medium. Both 2.31.0 advisories are rated High (GHSA-j8j4-rw65-56r6 CVSS 8.5, GHSA-6j3h-rp73-6rvf CVSS 8.2), so this changes the label to High.